### PR TITLE
Draft: Remove deprecated jump threshold from Cartesian plan

### DIFF
--- a/exercise1/src/exercise1-2/solution/main.cpp
+++ b/exercise1/src/exercise1-2/solution/main.cpp
@@ -49,10 +49,9 @@ int main(int argc, char* argv[])
 
     // Exercise 1-2 Plan a Cartesian path
     moveit_msgs::msg::RobotTrajectory trajectory;
-    const double jump_threshold = 0.0;
     const double eef_step = 0.002;
 
-    const double fraction = move_group_interface.computeCartesianPath(waypoints, eef_step, jump_threshold, trajectory);
+    const double fraction = move_group_interface.computeCartesianPath(waypoints, eef_step, trajectory);
 
     if (fraction > 0)
     {


### PR DESCRIPTION
Since https://github.com/moveit/moveit2/pull/2916, we deprecate jump_threshold.

This will eventually start giving us warnings. This PR is in draft until then. Ideally, we don't want to use deprecated code in the workshop. 